### PR TITLE
Nur Einträge mit Status 1 oder 0 ausgeben

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -5,7 +5,6 @@ if (rex_addon::get('cronjob')->isAvailable() && !rex::isSafeMode()) {
 }
 
 if (rex_addon::get('yform')->isAvailable() && !rex::isSafeMode()) {
-
     rex_yform_manager_dataset::setModelClass(
         'rex_neues_entry',
         neues_entry::class,
@@ -22,7 +21,6 @@ if (rex_addon::get('yform')->isAvailable() && !rex::isSafeMode()) {
         'rex_neues_entry_lang',
         neues_entry_lang::class,
     );
-
 }
 
 if (rex::isBackend() && 'neues/entry' == rex_be_controller::getCurrentPage() || 'yform/manager/data_edit' == rex_be_controller::getCurrentPage()) {

--- a/install.php
+++ b/install.php
@@ -6,7 +6,6 @@ if (rex_addon::get('yform') && rex_addon::get('yform')->isAvailable()) {
 }
 
 if (!rex_media::get('neues_entry_fallback_image.png')) {
-
     rex_file::copy(rex_path::addon('neues', '/install/neues_entry_fallback_image.png'), rex_path::media('neues_entry_fallback_image.png'));
     $data = [];
     $data['title'] = 'Aktuelles - Fallback-Image';
@@ -30,9 +29,7 @@ if (rex_addon::get('cronjob') && rex_addon::get('cronjob')->isAvailable()) {
 
 /* URL-Profile installieren */
 if (rex_addon::get('url') && rex_addon::get('url')->isAvailable()) {
-
     if (false === rex_config::get('neues', 'url_profile', false)) {
-
         $rex_neues_category = array_filter(rex_sql::factory()->getArray("SELECT * FROM rex_url_generator_profile WHERE `table_name` = '1_xxx_rex_neues_category'"));
         if (!$rex_neues_category) {
             $query = rex_file::get(rex_path::addon('neues', 'install/rex_url_profile_neues_category.sql'));

--- a/lib/neues.php
+++ b/lib/neues.php
@@ -19,7 +19,7 @@ class neues
     public static function getList(int $rowsPerPage = 10, string $pageCursor = 'page'): string
     {
         $query = neues_entry::query()
-            ->whereRaw('status = 0 OR status = 1')
+            ->where('status', 1, '>=')
             ->where('publishdate', rex_sql::datetime(), '<=')
             ->orderBy('publishdate', 'desc');
         $pager = new rex_pager($rowsPerPage, $pageCursor);

--- a/lib/neues.php
+++ b/lib/neues.php
@@ -18,7 +18,10 @@ class neues
      */
     public static function getList(int $rowsPerPage = 10, string $pageCursor = 'page'): string
     {
-        $query = neues_entry::query()->orderBy('publishdate', 'desc');
+        $query = neues_entry::query()
+            ->whereRaw('status = 0 OR status = 1')
+            ->where('publishdate', rex_sql::datetime(), '<=')
+            ->orderBy('publishdate', 'desc');
         $pager = new rex_pager($rowsPerPage, $pageCursor);
         $posts = $query->paginate($pager);
 

--- a/lib/rex_cronjob_neues_publish.php
+++ b/lib/rex_cronjob_neues_publish.php
@@ -4,7 +4,6 @@ class rex_cronjob_neues_publish extends rex_cronjob
 {
     public function execute()
     {
-
         /* Collection von Neues-Einträgen, die noch nicht veröffentlicht sind, aber es sein sollten. (geplant) */
         $neues_entry_to_publish = neues_entry::query()->where('status', 0)->where('publishdate', date('Y-m-d'), '<')->find();
         $neues_entry_to_publish->setValue('status', 1);


### PR DESCRIPTION
Es werden nur noch Einträge die veröffentlicht sind ausgegeben, oder Einträge die geplant sind und deren Datum und Uhrzeit erreicht ist.