### PR TITLE
Kleine Tricks in Sachen ModelClass

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -5,47 +5,37 @@ namespace FriendsOfRedaxo\Neues;
 use rex;
 use rex_addon;
 use rex_api_function;
-use rex_be_controller;
-use rex_config;
 use rex_cronjob_manager;
+use rex_cronjob_neues_publish;
+use rex_cronjob_neues_sync;
 use rex_csrf_token;
 use rex_extension;
-use rex_extension_point;
 use rex_plugin;
 use rex_url;
 use rex_yform_manager_dataset;
-use rex_yform_manager_table;
 
 if (rex_addon::get('cronjob')->isAvailable() && !rex::isSafeMode()) {
-    rex_cronjob_manager::registerType(\rex_cronjob_neues_publish::class);
-    rex_cronjob_manager::registerType(\rex_cronjob_neues_sync::class);
+    rex_cronjob_manager::registerType(rex_cronjob_neues_publish::class);
+    rex_cronjob_manager::registerType(rex_cronjob_neues_sync::class);
 }
 
 if (rex_addon::get('yform')->isAvailable() && !rex::isSafeMode()) {
     rex_yform_manager_dataset::setModelClass(
-        'rex_neues_entry',
+        rex::getTable('neues_entry'),
         Entry::class,
     );
     rex_yform_manager_dataset::setModelClass(
-        'rex_neues_category',
+        rex::getTable('neues_category'),
         Category::class,
     );
     rex_yform_manager_dataset::setModelClass(
-        'rex_neues_author',
+        rex::getTable('neues_author'),
         Author::class,
     );
     rex_yform_manager_dataset::setModelClass(
-        'rex_neues_entry_lang',
+        rex::getTable('neues_entry_lang'),
         EntryLang::class,
     );
-}
-
-if (rex::isBackend() && 'neues/entry' == rex_be_controller::getCurrentPage() || 'yform/manager/data_edit' == rex_be_controller::getCurrentPage()) {
-    rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) {
-        $suchmuster = 'class="###neues-settings-editor###"';
-        $ersetzen = rex_config::get('neues', 'editor');
-        $ep->setSubject(str_replace($suchmuster, $ersetzen, $ep->getSubject()));
-    });
 }
 
 rex_api_function::register('neues_rss', neues_rss_api::class);
@@ -54,69 +44,19 @@ if (rex_plugin::get('yform', 'rest')->isAvailable() && !rex::isSafeMode()) {
     RestfulApi::init();
 }
 
-rex_extension::register('YFORM_DATA_LIST', static function ($ep) {
-    if ('rex_neues_entry' == $ep->getParam('table')->getTableName()) {
-        $list = $ep->getSubject();
+rex_extension::register('YFORM_DATA_LIST', Entry::epYformDataList(...));
 
-        $list->setColumnFormat(
-            'name',
-            'custom',
-            static function ($a) {
-                $_csrf_key = rex_yform_manager_table::get('rex_neues_entry')->getCSRFKey();
-                $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
-
-                $params = [];
-                $params['table_name'] = 'rex_neues_entry';
-                $params['rex_yform_manager_popup'] = '0';
-                $params['_csrf_token'] = $token['_csrf_token'];
-                $params['data_id'] = $a['list']->getValue('id');
-                $params['func'] = 'edit';
-
-                return '<a href="' . rex_url::backendPage('neues/entry', $params) . '">' . $a['value'] . '</a>';
-            },
-        );
-        $list->setColumnFormat(
-            'neues_category_id',
-            'custom',
-            static function ($a) {
-                $_csrf_key = rex_yform_manager_table::get('rex_neues_category')->getCSRFKey();
-                $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
-
-                $params = [];
-                $params['table_name'] = 'rex_neues_category';
-                $params['rex_yform_manager_popup'] = '0';
-                $params['_csrf_token'] = $token['_csrf_token'];
-                $params['data_id'] = $a['list']->getValue('id');
-                $params['func'] = 'edit';
-
-                $return = [];
-
-                $category_ids = array_filter(array_map('intval', explode(',', $a['value'])));
-
-                foreach ($category_ids as $category_id) {
-                    /** @var $neues_category neues_category */
-                    $neues_category = Category::get($category_id);
-                    if ($neues_category) {
-                        $return[] = '<a href="' . rex_url::backendPage('neues/category', $params) . '">' . $neues_category->getName() . '</a>';
-                    }
-                }
-                return implode('<br>', $return);
-            },
-        );
-    }
-});
-
-if (rex::isBackend() && \rex_addon::get('neues') && \rex_addon::get('neues')->isAvailable() && !rex::isSafeMode()) {
+if (rex::isBackend() && rex_addon::get('neues') && rex_addon::get('neues')->isAvailable() && !rex::isSafeMode()) {
     $addon = rex_addon::get('neues');
     $pages = $addon->getProperty('pages');
 
-    if($_REQUEST) {
-        $_csrf_key = rex_yform_manager_table::get('rex_neues_entry')->getCSRFKey();
-        
+    if ($_REQUEST) {
+        $_csrf_key = Entry::table()->getCSRFKey();
+
         $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
 
         $params = [];
-        $params['table_name'] = 'rex_neues_entry'; // Tabellenname anpassen
+        $params['table_name'] = Entry::table()->getTableName(); // Tabellenname anpassen
         $params['rex_yform_manager_popup'] = '0';
         $params['_csrf_token'] = $token['_csrf_token'];
         $params['func'] = 'add';

--- a/install.php
+++ b/install.php
@@ -4,6 +4,7 @@ namespace FriendsOfRedaxo\Neues;
 
 use rex;
 use rex_addon;
+use rex_article;
 use rex_config;
 use rex_file;
 use rex_media;
@@ -23,7 +24,6 @@ if (rex_addon::get('yform') && rex_addon::get('yform')->isAvailable()) {
     $sql->setQuery('UPDATE ' . rex::getTable('neues_entry') . ' SET uuid = uuid() WHERE uuid IS NULL OR uuid = ""');
 
     require_once __DIR__ . '/install/update_scheme.php';
-    
 }
 
 if (!rex_media::get('neues_entry_fallback_image.png')) {
@@ -53,12 +53,12 @@ if (rex_addon::get('url') && rex_addon::get('url')->isAvailable()) {
     if (false === rex_config::get('neues', 'url_profile', false)) {
         $rex_neues_category = array_filter(rex_sql::factory()->getArray("SELECT * FROM rex_url_generator_profile WHERE `table_name` = '1_xxx_rex_neues_category'"));
         if (!$rex_neues_category) {
-            $query = \str_replace("999999", \rex_article::getSiteStartArticleId(), rex_file::get(__DIR__ . '/install/rex_url_profile_neues_category.sql'));
+            $query = str_replace('999999', rex_article::getSiteStartArticleId(), rex_file::get(__DIR__ . '/install/rex_url_profile_neues_category.sql'));
             rex_sql::factory()->setQuery($query);
         }
         $rex_neues_entry = array_filter(rex_sql::factory()->getArray("SELECT * FROM rex_url_generator_profile WHERE `table_name` = '1_xxx_rex_neues_entry'"));
         if (!$rex_neues_entry) {
-            $query = \str_replace("999999", \rex_article::getSiteStartArticleId(), rex_file::get(__DIR__ . '/install/rex_url_profile_neues_entry.sql'));
+            $query = str_replace('999999', rex_article::getSiteStartArticleId(), rex_file::get(__DIR__ . '/install/rex_url_profile_neues_entry.sql'));
             rex_sql::factory()->setQuery($query);
         }
         /* URL-Profile wurden bereits einmal installiert, daher nicht nochmals installieren und Entwickler-Einstellungen respektieren */

--- a/install/update_scheme.php
+++ b/install/update_scheme.php
@@ -51,5 +51,3 @@ rex_sql_table::get(rex::getTable('neues_entry_category_rel'))
     ->ensureColumn(new rex_sql_column('category_id', 'int(10) unsigned'))
     ->ensureIndex(new rex_sql_index('entry_id_category_id', ['entry_id', 'category_id'], rex_sql_index::UNIQUE))
     ->ensure();
-    
-?>

--- a/lib/neues.php
+++ b/lib/neues.php
@@ -2,13 +2,9 @@
 
 namespace FriendsOfRedaxo\Neues;
 
-use rex;
 use rex_fragment;
 use rex_pager;
 use rex_sql;
-use rex_sql_column;
-use rex_sql_index;
-use rex_sql_table;
 
 class Neues
 {

--- a/lib/neues_entry.php
+++ b/lib/neues_entry.php
@@ -5,11 +5,16 @@ namespace FriendsOfRedaxo\Neues;
 use IntlDateFormatter;
 use rex_addon;
 use rex_config;
+use rex_csrf_token;
+use rex_extension_point;
 use rex_formatter;
 use rex_media;
 use rex_media_plus;
+use rex_url;
+use rex_yform;
 use rex_yform_manager_collection;
 use rex_yform_manager_dataset;
+use rex_yform_manager_table;
 
 /**
  * Class neues_entry.
@@ -24,6 +29,26 @@ use rex_yform_manager_dataset;
  */
 class Entry extends rex_yform_manager_dataset
 {
+    /**
+     * Standards für das Formular anpassen
+     * - Editor-Konfiguration einfügen.
+     *
+     * @api
+     */
+    public function getForm(): rex_yform
+    {
+        $yform = parent::getForm();
+
+        $suchtext = '###neues-settings-editor###';
+        foreach ($yform->objparams['form_elements'] as $k => &$e) {
+            if ('textarea' === $e[0] && str_contains($e[5], $suchtext)) {
+                $e[5] = str_replace($suchtext, rex_config::get('neues', 'editor'), $e[5]);
+            }
+        }
+
+        return $yform;
+    }
+
     /**
      * @api
      */
@@ -44,6 +69,71 @@ class Entry extends rex_yform_manager_dataset
     {
         $this->setValue('name', $name);
         return $this;
+    }
+
+    /**
+     * YFORM_DATA_LIST: passt die Listendarstellung an.
+     *
+     * @api
+     * @param rex_extension_point<rex_yform_list> $ep
+     * @return void|rex_yform_list
+     */
+    public static function epYformDataList(rex_extension_point $ep)
+    {
+        /** @var rex_yform_manager_table $table */
+        $table = $ep->getParam('table');
+        if ($table->getTableName() !== self::table()->getTableName()) {
+            return;
+        }
+
+        /** @var rex_yform_list $list */
+        $list = $ep->getSubject();
+
+        $list->setColumnFormat(
+            'name',
+            'custom',
+            static function ($a) {
+                $_csrf_key = Entry::table()->getCSRFKey();
+                $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
+
+                $params = [];
+                $params['table_name'] = Entry::table()->getTableName();
+                $params['rex_yform_manager_popup'] = '0';
+                $params['_csrf_token'] = $token['_csrf_token'];
+                $params['data_id'] = $a['list']->getValue('id');
+                $params['func'] = 'edit';
+
+                return '<a href="' . rex_url::backendPage('neues/entry', $params) . '">' . $a['value'] . '</a>';
+            },
+        );
+        $list->setColumnFormat(
+            'neues_category_id',
+            'custom',
+            static function ($a) {
+                $_csrf_key = Category::table()->getCSRFKey();
+                $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
+
+                $params = [];
+                $params['table_name'] = Category::table()->getTableName();
+                $params['rex_yform_manager_popup'] = '0';
+                $params['_csrf_token'] = $token['_csrf_token'];
+                $params['data_id'] = $a['list']->getValue('id');
+                $params['func'] = 'edit';
+
+                $return = [];
+
+                $category_ids = array_filter(array_map('intval', explode(',', $a['value'])));
+
+                foreach ($category_ids as $category_id) {
+                    /** @var null|Category $neues_category */
+                    $neues_category = Category::get($category_id);
+                    if (null !== $neues_category) {
+                        $return[] = '<a href="' . rex_url::backendPage('neues/category', $params) . '">' . $neues_category->getName() . '</a>';
+                    }
+                }
+                return implode('<br>', $return);
+            },
+        );
     }
 
     /**
@@ -426,7 +516,9 @@ class Entry extends rex_yform_manager_dataset
      */
     public static function findByCategory(?int $category_id = null, int $status = 1): ?rex_yform_manager_collection
     {
-        $query = self::query()->joinRelation('category_ids', 'c')->where('rex_neues_entry.status', $status, '>=')->where('c.id', $category_id);
+        $query = self::query();
+        $alias = $query->getTableAlias();
+        $query->joinRelation('category_ids', 'c')->where($alias . '.status', $status, '>=')->where('c.id', $category_id);
         return $query->find();
     }
 

--- a/lib/neues_entry.php
+++ b/lib/neues_entry.php
@@ -125,7 +125,7 @@ class Entry extends rex_yform_manager_dataset
                 $category_ids = array_filter(array_map('intval', explode(',', $a['value'])));
 
                 foreach ($category_ids as $category_id) {
-                    /** @var null|Category $neues_category */
+                    /** @var Category|null $neues_category */
                     $neues_category = Category::get($category_id);
                     if (null !== $neues_category) {
                         $return[] = '<a href="' . rex_url::backendPage('neues/category', $params) . '">' . $neues_category->getName() . '</a>';

--- a/lib/neues_restful_api.php
+++ b/lib/neues_restful_api.php
@@ -2,12 +2,13 @@
 
 namespace FriendsOfRedaxo\Neues;
 
-use rex_yform_rest_route;
 use rex_yform_rest;
+use rex_yform_rest_route;
 
-class RestfulApi {
-
-    public static function init() :void {
+class RestfulApi
+{
+    public static function init(): void
+    {
         $rex_neues_entry_route = new rex_yform_rest_route(
             [
                 'path' => '/neues/entry/5.0.0/',
@@ -92,9 +93,9 @@ class RestfulApi {
                 ],
             ],
         );
-    
+
         rex_yform_rest::addRoute($rex_neues_entry_route);
-    
+
         /* YForm Rest API */
         $rex_neues_category_route = new rex_yform_rest_route(
             [
@@ -136,9 +137,9 @@ class RestfulApi {
                 ],
             ],
         );
-    
+
         rex_yform_rest::addRoute($rex_neues_category_route);
-    
+
         /* YForm Rest API */
         $rex_neues_author_route = new rex_yform_rest_route(
             [
@@ -183,9 +184,7 @@ class RestfulApi {
                 ],
             ],
         );
-    
-        rex_yform_rest::addRoute($rex_neues_author_route);
-    
-    }
 
+        rex_yform_rest::addRoute($rex_neues_author_route);
+    }
 }

--- a/lib/rex_cronjob_neues_publish.php
+++ b/lib/rex_cronjob_neues_publish.php
@@ -1,6 +1,6 @@
 <?php
 
-
+use FriendsOfRedaxo\Neues\Entry;
 
 use function count;
 
@@ -9,7 +9,7 @@ class rex_cronjob_neues_publish extends rex_cronjob
     public function execute()
     {
         /* Collection von Neues-Einträgen, die noch nicht veröffentlicht sind, aber es sein sollten. (geplant) */
-        $neues_entry_to_publish = FriendsOfRedaxo\Neues\Entry::query()->where('status', 0)->where('publishdate', date('Y-m-d'), '<')->find();
+        $neues_entry_to_publish = Entry::query()->where('status', 0)->where('publishdate', date('Y-m-d'), '<')->find();
         $neues_entry_to_publish->setValue('status', 1);
         if (!$neues_entry_to_publish->save()) {
             $this->setMessage(sprintf(rex_i18n::msg('neues_entry_publish_error'), count($neues_entry_to_publish)));

--- a/lib/rex_cronjob_neues_sync.php
+++ b/lib/rex_cronjob_neues_sync.php
@@ -1,5 +1,9 @@
 <?php
 
+use FriendsOfRedaxo\Neues\Author;
+use FriendsOfRedaxo\Neues\Category;
+use FriendsOfRedaxo\Neues\Entry;
+
 class rex_cronjob_neues_sync extends rex_cronjob
 {
     private $rest_urls = ['category' => '/rest/neues/category/5.0.0/',
@@ -28,15 +32,14 @@ class rex_cronjob_neues_sync extends rex_cronjob
             $data[$type] = json_decode($response->getBody(), true);
         }
 
-        if(isset($data['category']['data'])) {
-
+        if (isset($data['category']['data'])) {
             foreach ($data['category']['data'] as $category) {
                 $category = $category['attributes'];
 
                 // Überprüfe, ob UUID bereits in der Datenbank vorhanden ist
-                $neues_category = FriendsOfRedaxo\Neues\Category::query()->where('uuid', $category['uuid'])->findOne();
+                $neues_category = Category::query()->where('uuid', $category['uuid'])->findOne();
                 if (null === $neues_category) {
-                    $neues_category = FriendsOfRedaxo\Neues\Category::create();
+                    $neues_category = Category::create();
                 }
 
                 $neues_category->setValue('uuid', $category['uuid']);
@@ -51,15 +54,14 @@ class rex_cronjob_neues_sync extends rex_cronjob
             }
         }
 
-        if(isset($data['author']['data'])) {
-
+        if (isset($data['author']['data'])) {
             foreach ($data['author']['data'] as $author) {
                 $author = $author['attributes'];
 
                 // Überprüfe, ob UUID bereits in der Datenbank vorhanden ist
-                $neues_author = FriendsOfRedaxo\Neues\Author::query()->where('uuid', $author['uuid'])->findOne();
+                $neues_author = Author::query()->where('uuid', $author['uuid'])->findOne();
                 if (null === $neues_author) {
-                    $neues_author = FriendsOfRedaxo\Neues\Author::create();
+                    $neues_author = Author::create();
                 }
 
                 $neues_author->setValue('uuid', $author['uuid']);
@@ -73,11 +75,10 @@ class rex_cronjob_neues_sync extends rex_cronjob
         foreach ($data['entry']['data'] as $entry) {
             $entry = $entry['attributes'];
             // Überprüfe, ob UUID bereits in der Datenbank vorhanden ist
-            $neues_entry = FriendsOfRedaxo\Neues\Entry::query()->where('uuid', $entry['uuid'])->findOne();
+            $neues_entry = Entry::query()->where('uuid', $entry['uuid'])->findOne();
             if (null === $neues_entry) {
-                $neues_entry = FriendsOfRedaxo\Neues\Entry::create();
+                $neues_entry = Entry::create();
             }
-
 
             $neues_entry->setValue('uuid', $entry['uuid']);
             $neues_entry->setValue('name', $entry['name']);
@@ -127,6 +128,6 @@ class rex_cronjob_neues_sync extends rex_cronjob
             ],
         ];
 
-        return  $fields;
+        return $fields;
     }
 }


### PR DESCRIPTION
Ich hab mir erlaubt, Teile aus der `boot.php` in die Entry-Klasse zu verlagern und drum herum ein paar Kleinigkeiten zu bügeln:

- `"###neues-settings-editor###"`durch den Zielwert zu rsetzen passiert jetzt in `Entry->getForm()`
- Die Callback-Methode für den EP YFORM_DATA_LIST liegt nun in der Entry-Klasse als `Entry::epYformDataList()`
- Die Tabellennamen werden nun durch `rex::getTable()` erzeugt. Auch wenn es eh immer nur auf den Prefix rex_ hinausläuft.
- Hier erstmal prototypisch beschränkt auf `boot.php` und die Entry-Klasse:
  - Table-Instanz über die Model-Class holen: `Entry::table()` statt `rex_yform_manager_table::get('rex_neues_entry')`
  - Tabellennamen über die Model-Class holen: `Entry::table()->getTablename()` statt `'rex_neues_entry'`
  - In der Query nicht mit einem festen Alias arbeiten (`rex_neues_entry.status`), sondern den Alias aus der Query abrufen und nutzen (`$alias-'.status'`) 

Letzteres damit der reale Tabellenname möglichst nur einmal benutzt wird, nämlich bei der Zuweisung der Modell-Class.

Rudimentär getestet; Tabelle und Formular werden via Tablemanager wie erwartet angezeigt; `getForm` und  `epYformDataList` werden aufgerufen.