### PR TITLE
boot.php gestrafft

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -12,51 +12,73 @@ use rex_plugin;
 use rex_url;
 use rex_yform_manager_dataset;
 
-if (rex_addon::get('cronjob')->isAvailable() && !rex::isSafeMode()) {
+use function count;
+
+/**
+ * Cronjobs nur bereitstellen, wenn das Addon verfügbar ist
+ * (optionales Feature).
+ */
+if (rex_addon::get('cronjob')->isAvailable()) {
     rex_cronjob_manager::registerType(Cronjob\Publish::class);
     rex_cronjob_manager::registerType(Cronjob\Sync::class);
 }
 
-if (rex_addon::get('yform')->isAvailable() && !rex::isSafeMode()) {
-    rex_yform_manager_dataset::setModelClass(
-        rex::getTable('neues_entry'),
-        Entry::class,
-    );
-    rex_yform_manager_dataset::setModelClass(
-        rex::getTable('neues_category'),
-        Category::class,
-    );
-    rex_yform_manager_dataset::setModelClass(
-        rex::getTable('neues_author'),
-        Author::class,
-    );
-    rex_yform_manager_dataset::setModelClass(
-        rex::getTable('neues_entry_lang'),
-        EntryLang::class,
-    );
-}
+/**
+ * Tabellen in YForm mit eigener Model-Class.
+ */
+rex_yform_manager_dataset::setModelClass(
+    rex::getTable('neues_entry'),
+    Entry::class,
+);
+rex_yform_manager_dataset::setModelClass(
+    rex::getTable('neues_category'),
+    Category::class,
+);
+rex_yform_manager_dataset::setModelClass(
+    rex::getTable('neues_author'),
+    Author::class,
+);
+rex_yform_manager_dataset::setModelClass(
+    rex::getTable('neues_entry_lang'),
+    EntryLang::class,
+);
 
+/**
+ * RSS-Fead via rex-api.
+ */
 rex_api_function::register('neues_rss', Api\Rss::class);
 
-if (rex_plugin::get('yform', 'rest')->isAvailable() && !rex::isSafeMode()) {
+/**
+ * REST-API aktivieren wenn das YForm-REST-Plugin aktiviert ist
+ * (optionales Feature).
+ */
+if (rex_plugin::get('yform', 'rest')->isAvailable()) {
     Api\Restful::init();
 }
 
-rex_extension::register('YFORM_DATA_LIST', Entry::epYformDataList(...));
-
-if (rex::isBackend() && rex_addon::get('neues') && rex_addon::get('neues')->isAvailable() && !rex::isSafeMode()) {
+if (rex::isBackend()) {
     $addon = rex_addon::get('neues');
     $pages = $addon->getProperty('pages');
 
-    if ($_REQUEST) {
+    /**
+     * Individualiserte Liste für Enries.
+     */
+    rex_extension::register('YFORM_DATA_LIST', Entry::epYformDataList(...));
+
+    /**
+     * Plus(Add)-Button im Hauptmenü-Punkt des Addon bereitstellen.
+     * 
+     * RexStan: Using $_REQUEST is forbidden, use rex_request::request() or rex_request() instead.
+     * Kommentar: kein Alternative verfügbar
+     * @phpstan-ignore-next-line
+     */
+    if (0 < count($_REQUEST)) {
         $_csrf_key = Entry::table()->getCSRFKey();
 
-        $token = rex_csrf_token::factory($_csrf_key)->getUrlParams();
+        $params = rex_csrf_token::factory($_csrf_key)->getUrlParams();
 
-        $params = [];
         $params['table_name'] = Entry::table()->getTableName(); // Tabellenname anpassen
         $params['rex_yform_manager_popup'] = '0';
-        $params['_csrf_token'] = $token['_csrf_token'];
         $params['func'] = 'add';
 
         $href = rex_url::backendPage('neues/entry', $params);

--- a/boot.php
+++ b/boot.php
@@ -15,15 +15,6 @@ use rex_yform_manager_dataset;
 use function count;
 
 /**
- * Cronjobs nur bereitstellen, wenn das Addon verfügbar ist
- * (optionales Feature).
- */
-if (rex_addon::get('cronjob')->isAvailable()) {
-    rex_cronjob_manager::registerType(Cronjob\Publish::class);
-    rex_cronjob_manager::registerType(Cronjob\Sync::class);
-}
-
-/**
  * Tabellen in YForm mit eigener Model-Class.
  */
 rex_yform_manager_dataset::setModelClass(
@@ -44,14 +35,19 @@ rex_yform_manager_dataset::setModelClass(
 );
 
 /**
- * RSS-Fead via rex-api.
+ * RSS-Fead via rex-api anbieten.
  */
 rex_api_function::register('neues_rss', Api\Rss::class);
 
 /**
- * REST-API aktivieren wenn das YForm-REST-Plugin aktiviert ist
- * (optionales Feature).
+ * Optionale Dienste:
+ * - Cronjobs nur bereitstellen, wenn das Addon verfügbar ist
+ * - REST-API nur aktivieren wenn das YForm-REST-Plugin aktiviert ist
  */
+if (rex_addon::get('cronjob')->isAvailable()) {
+    rex_cronjob_manager::registerType(Cronjob\Publish::class);
+    rex_cronjob_manager::registerType(Cronjob\Sync::class);
+}
 if (rex_plugin::get('yform', 'rest')->isAvailable()) {
     Api\Restful::init();
 }
@@ -69,7 +65,7 @@ if (rex::isBackend()) {
      * Plus(Add)-Button im Hauptmenü-Punkt des Addon bereitstellen.
      * 
      * RexStan: Using $_REQUEST is forbidden, use rex_request::request() or rex_request() instead.
-     * Kommentar: kein Alternative verfügbar
+     * Kommentar: Für diese Nutzung ist keine rex-Alternative verfügbar
      * @phpstan-ignore-next-line
      */
     if (0 < count($_REQUEST)) {

--- a/package.yml
+++ b/package.yml
@@ -6,13 +6,11 @@ load: late
 
 requires:
     php:
-
         version: '>7.3,<9'
     redaxo: ^5.17
-
-
     packages:
         yform: '^4'
+        yform/manager: '^4'
         yform_field: '^2.3.0'
 
 page:


### PR DESCRIPTION
_boot.php_ etwas gestrafft:

- m.E. unnötige Verfügbarkeitsabfragen entfernt.
- deshalb in der _package.yml_ den Punkt `requires` um `yform/manager`ergänzt.
- Kommentare eingefügt
- Optionale Teile als Block
- Modelclass-Zuweisung ganz nach vorne geschoben
- RexStan-Überprüfung