### PR TITLE
API und Cronjobs mit RexStan bearbeitet

### DIFF
--- a/lang/da_da.lang
+++ b/lang/da_da.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s indlæg er blevet offentliggjort med succes.
-neues_entry_publish_error = %s indlæg kunne ikke offentliggøres.
+neues_entry_publish_success = %d indlæg er blevet offentliggjort med succes.
+neues_entry_publish_error = %d indlæg kunne ikke offentliggøres.
 neues_entry_publish_cronjob = Offentliggør planlagte indlæg. (Aktuelt)

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -100,8 +100,8 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s Beiträge wurden erfolgreich veröffentlicht.
-neues_entry_publish_error = %s Beiträge konnten nicht veröffentlicht werden.
+neues_entry_publish_success = %d Beiträge wurden erfolgreich veröffentlicht.
+neues_entry_publish_error = %d Beiträge konnten nicht veröffentlicht werden.
 neues_entry_publish_cronjob = Geplante Beiträge veröffentlichen. (Aktuelles)
 
 neues_entry_sync_error = Fehler beim Synchronisieren der Beiträge.

--- a/lang/el_el.lang
+++ b/lang/el_el.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s Καταχωρήσεις δημοσιεύτηκαν επιτυχώς.
-neues_entry_publish_error = %s Καταχωρήσεις δεν μπόρεσαν να δημοσιευτούν.
+neues_entry_publish_success = %d Καταχωρήσεις δημοσιεύτηκαν επιτυχώς.
+neues_entry_publish_error = %d Καταχωρήσεις δεν μπόρεσαν να δημοσιευτούν.
 neues_entry_publish_cronjob = Δημοσίευση προγραμματισμένων καταχωρήσεων. (Νέα)

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -91,6 +91,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s posts have been successfully published.
-neues_entry_publish_error = %s posts could not be published.
+neues_entry_publish_success = %d posts have been successfully published.
+neues_entry_publish_error = %d posts could not be published.
 neues_entry_publish_cronjob = Publish planned posts. (Current)

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -90,6 +90,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s entradas se han publicado con éxito.
-neues_entry_publish_error = %s entradas no se pudieron publicar.
+neues_entry_publish_success = %d entradas se han publicado con éxito.
+neues_entry_publish_error = %d entradas no se pudieron publicar.
 neues_entry_publish_cronjob = Publicar entradas planificadas. (Actual)

--- a/lang/fi_fi.lang
+++ b/lang/fi_fi.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s artikkelia on julkaistu onnistuneesti.
-neues_entry_publish_error = %s artikkelia ei voitu julkaista.
+neues_entry_publish_success = %d artikkelia on julkaistu onnistuneesti.
+neues_entry_publish_error = %d artikkelia ei voitu julkaista.
 neues_entry_publish_cronjob = Julkaise suunnitellut artikkelit. (Uutiset)

--- a/lang/fr_fr.lang
+++ b/lang/fr_fr.lang
@@ -91,6 +91,6 @@ neues_docs_restful_api = API RESTful YForm
 
 # Cronjob
 
-neues_entry_publish_success = %s articles ont été publiés avec succès.
-neues_entry_publish_error = %s articles n'ont pas pu être publiés.
+neues_entry_publish_success = %d articles ont été publiés avec succès.
+neues_entry_publish_error = %d articles n'ont pas pu être publiés.
 neues_entry_publish_cronjob = Publier des articles planifiés. (Actuel)

--- a/lang/it_it.lang
+++ b/lang/it_it.lang
@@ -91,6 +91,6 @@ neues_docs_restful_api = YForm API RESTful
 
 # Cronjob
 
-neues_entry_publish_success = %s articoli sono stati pubblicati con successo.
-neues_entry_publish_error = %s articoli non sono stati pubblicati.
+neues_entry_publish_success = %d articoli sono stati pubblicati con successo.
+neues_entry_publish_error = %d articoli non sono stati pubblicati.
 neues_entry_publish_cronjob = Pubblica articoli pianificati. (Corrente)

--- a/lang/nl_nl.lang
+++ b/lang/nl_nl.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s berichten zijn succesvol gepubliceerd.
-neues_entry_publish_error = %s berichten konden niet worden gepubliceerd.
+neues_entry_publish_success = %d berichten zijn succesvol gepubliceerd.
+neues_entry_publish_error = %d berichten konden niet worden gepubliceerd.
 neues_entry_publish_cronjob = Geplande berichten publiceren. (Nieuws)

--- a/lang/no_no.lang
+++ b/lang/no_no.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s innlegg har blitt publisert.
-neues_entry_publish_error = %s innlegg kunne ikke publiseres.
+neues_entry_publish_success = %d innlegg har blitt publisert.
+neues_entry_publish_error = %d innlegg kunne ikke publiseres.
 neues_entry_publish_cronjob = Publiser planlagte innlegg. (Aktuelt)

--- a/lang/pl_pl.lang
+++ b/lang/pl_pl.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s wpisów zostało pomyślnie opublikowanych.
-neues_entry_publish_error = %s wpisów nie udało się opublikować.
+neues_entry_publish_success = %d wpisów zostało pomyślnie opublikowanych.
+neues_entry_publish_error = %d wpisów nie udało się opublikować.
 neues_entry_publish_cronjob = Publikowanie zaplanowanych wpisów. (Aktualności)

--- a/lang/ro_ro.lang
+++ b/lang/ro_ro.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s articole au fost publicate cu succes.
-neues_entry_publish_error = %s articole nu au putut fi publicate.
+neues_entry_publish_success = %d articole au fost publicate cu succes.
+neues_entry_publish_error = %d articole nu au putut fi publicate.
 neues_entry_publish_cronjob = Publică articolele planificate. (Noutăți)

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -90,6 +90,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s inlägg har publicerats framgångsrikt.
-neues_entry_publish_error = %s inlägg kunde inte publiceras.
+neues_entry_publish_success = %d inlägg har publicerats framgångsrikt.
+neues_entry_publish_error = %d inlägg kunde inte publiceras.
 neues_entry_publish_cronjob = Publicera planerade inlägg.

--- a/lang/tr_tr.lang
+++ b/lang/tr_tr.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s giriş başarıyla yayınlandı.
-neues_entry_publish_error = %s giriş yayınlanamadı.
+neues_entry_publish_success = %d giriş başarıyla yayınlandı.
+neues_entry_publish_error = %d giriş yayınlanamadı.
 neues_entry_publish_cronjob = Planlanan girişleri yayınla. (Yeni)

--- a/lang/uk_uk.lang
+++ b/lang/uk_uk.lang
@@ -93,6 +93,6 @@ neues_docs_restful_api = YForm RESTful API
 
 # Cronjob
 
-neues_entry_publish_success = %s записів було успішно опубліковано.
-neues_entry_publish_error = %s записів не вдалося опублікувати.
+neues_entry_publish_success = %d записів було успішно опубліковано.
+neues_entry_publish_error = %d записів не вдалося опублікувати.
 neues_entry_publish_cronjob = Опублікувати заплановані записи. (Новини)

--- a/lib/Api/Restful.php
+++ b/lib/Api/Restful.php
@@ -20,7 +20,7 @@ class Restful
                 'query' => Entry::query(),
                 'get' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Entry' => [
+                        Entry::class => [
                             'id',
                             'status',
                             'name',
@@ -40,7 +40,7 @@ class Restful
                             'updateuser',
                             'uuid',
                         ],
-                        'FriendsOfRedaxo\Neues\Category' => [
+                        Category::class => [
                             'id',
                             'name',
                             'image',
@@ -51,7 +51,7 @@ class Restful
                             'updateuser',
                             'uuid',
                         ],
-                        'FriendsOfRedaxo\Neues\Author' => [
+                        Author::class => [
                             'id',
                             'name',
                             'nickname',
@@ -68,7 +68,7 @@ class Restful
                 ],
                 'post' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Entry' => [
+                        Entry::class => [
                             'status',
                             'name',
                             'teaser',
@@ -89,7 +89,7 @@ class Restful
                 ],
                 'delete' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Entry' => [
+                        Entry::class => [
                             'id',
                         ],
                     ],
@@ -108,7 +108,7 @@ class Restful
                 'query' => Category::query(),
                 'get' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Category' => [
+                        Category::class => [
                             'id',
                             'name',
                             'image',
@@ -123,7 +123,7 @@ class Restful
                 ],
                 'post' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Category' => [
+                        Category::class => [
                             'name',
                             'image',
                             'status',
@@ -133,7 +133,7 @@ class Restful
                 ],
                 'delete' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Category' => [
+                        Category::class => [
                             'id',
                         ],
                     ],
@@ -152,7 +152,7 @@ class Restful
                 'query' => Author::query(),
                 'get' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Author' => [
+                        Author::class => [
                             'id',
                             'name',
                             'nickname',
@@ -169,7 +169,7 @@ class Restful
                 ],
                 'post' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Author' => [
+                        Author::class => [
                             'name',
                             'nickname',
                             'text',
@@ -180,7 +180,7 @@ class Restful
                 ],
                 'delete' => [
                     'fields' => [
-                        'FriendsOfRedaxo\Neues\Author' => [
+                        Author::class => [
                             'id',
                         ],
                     ],

--- a/lib/Api/Rss.php
+++ b/lib/Api/Rss.php
@@ -55,7 +55,7 @@ class Rss extends rex_api_function
      * @param rex_yform_manager_collection<Entry> $collection
      * @api
      */
-    public static function getRssFeed(rex_yform_manager_collection $collection, string $domain, int $lang, string $description, string $filename): string|bool
+    public static function getRssFeed(rex_yform_manager_collection $collection, int $domain_id, int $lang, string $description, string $filename): string|bool
     {
         return self::createRssFeed($collection, $domain, $lang, $description, $filename);
     }

--- a/lib/Api/Rss.php
+++ b/lib/Api/Rss.php
@@ -54,10 +54,8 @@ class Rss extends rex_api_function
     /**
      * @param rex_yform_manager_collection<Entry> $collection
      * @api
-     *
-     * TODO: Parameter Domain wird nicht benutzt: Klären ob der weg kann. Type fehlt
      */
-    public static function getRssFeed($collection, $domain, int $lang, string $description, string $filename): string|bool
+    public static function getRssFeed(rex_yform_manager_collection $collection, string $domain, int $lang, string $description, string $filename): string|bool
     {
         return self::createRssFeed($collection, $domain, $lang, $description, $filename);
     }
@@ -73,10 +71,8 @@ class Rss extends rex_api_function
     /**
      * @param rex_yform_manager_collection<Entry> $collection
      * @api
-     *
-     * TODO: Parameter Domain wird nicht benutzt: Klären ob der weg kann. Type fehlt
      */
-    public static function createRssFeed(rex_yform_manager_collection $collection, $domain, int $lang, string $description, string $filename = 'rss.neues.xml'): string|bool
+    public static function createRssFeed(rex_yform_manager_collection $collection, string $domain, int $lang, string $description, string $filename = 'rss.neues.xml'): string|bool
     {
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom"></rss>');
 

--- a/lib/Api/Rss.php
+++ b/lib/Api/Rss.php
@@ -29,7 +29,7 @@ class Rss extends rex_api_function
         $category_id = rex_request('category_id', 'int', null);
 
         $category = null;
-        if(null !== $category_id) {
+        if (null !== $category_id) {
             $category = Category::get($category_id);
         }
 

--- a/lib/Api/Rss.php
+++ b/lib/Api/Rss.php
@@ -72,7 +72,7 @@ class Rss extends rex_api_function
      * @param rex_yform_manager_collection<Entry> $collection
      * @api
      */
-    public static function createRssFeed(rex_yform_manager_collection $collection, string $domain, int $lang, string $description, string $filename = 'rss.neues.xml'): string|bool
+    public static function createRssFeed(rex_yform_manager_collection $collection, int $domain_id, int $lang, string $description, string $filename = 'rss.neues.xml'): string|bool
     {
         $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom"></rss>');
 

--- a/lib/Api/Rss.php
+++ b/lib/Api/Rss.php
@@ -28,14 +28,19 @@ class Rss extends rex_api_function
         $lang_id = rex_request('lang_id', 'int', null);
         $category_id = rex_request('category_id', 'int', null);
 
-        if ($category_id && $category = Category::get($category_id)) {
+        $category = null;
+        if(null !== $category_id) {
+            $category = Category::get($category_id);
+        }
+
+        if (null !== $category) {
             $collection = Entry::findOnline($category_id);
             $filename = 'rss.neues.' . rex_string::normalize($category->getName()) . '.xml';
             $description = 'RSS-FEED: ' . rex::getServerName() . ' | ' . rex_escape($category->getName());
         } else {
             $collection = Entry::findOnline();
-            $description = 'RSS-FEED: ' . rex::getServerName();
             $filename = 'rss.neues.xml';
+            $description = 'RSS-FEED: ' . rex::getServerName();
         }
 
         rex_response::cleanOutputBuffers();
@@ -80,9 +85,7 @@ class Rss extends rex_api_function
         $channel->addChild('description', $description);
         $channel->addChild('link', rex::getServer());
 
-        // RexStan: Only booleans are allowed in &&, int given on the left side.
-        // TODO: klären was der Teil `$lang &&` bewirken soll und ggf. rauswerfen
-        if ($lang && $lang > 0) {
+        if ($lang > 0) {
             $channel->addChild('language', rex_clang::get($lang)->getCode());
         }
 

--- a/lib/Cronjob/Publish.php
+++ b/lib/Cronjob/Publish.php
@@ -10,6 +10,9 @@ use function count;
 
 class Publish extends rex_cronjob
 {
+    /**
+     * @return bool
+     */
     public function execute()
     {
         /* Collection von Neues-Einträgen, die noch nicht veröffentlicht sind, aber es sein sollten. (geplant) */

--- a/lib/Cronjob/Sync.php
+++ b/lib/Cronjob/Sync.php
@@ -17,7 +17,7 @@ class Sync extends rex_cronjob
         'entry' => '/rest/neues/entry/5.0.0/'];
 
     /**
-     * @return bool 
+     * @return bool
      */
     public function execute()
     {

--- a/lib/Cronjob/Sync.php
+++ b/lib/Cronjob/Sync.php
@@ -35,7 +35,7 @@ class Sync extends rex_cronjob
 
             if (!$response->isOk()) {
                 /**
-                 * REVIEW: in 'neues_entry_sync_error' ist kein Platzhalter für den Code. Code überflüssig?
+                 * TODO: in 'neues_entry_sync_error' Platzhalter für den Code. einfügen.
                  * TODO: reicht auch $this->setMessage(rex_i18n::msg('neues_entry_sync_error') ??
                  */
                 $this->setMessage(sprintf(rex_i18n::msg('neues_entry_sync_error'), $response->getStatusCode()));


### PR DESCRIPTION
Sync.php:

(Ja, ist noch in Arbeit.)

- nur einmal nötige Abrufe (`$this->getParam(...)`) vor die Schleife gezogen. Als Zusatznutzen meckert RexStan nicht mehr, wenn weiter unten `$status` verwendet wird ("möglicherweise nicht initialisiert") 
- Mit `REVIEW:`bzw. `FIXME:` markiert. Da stimmt was nicht. Bitte mal prüfen.
- Die .lang-Einträge sind noch unvollständig

Publish.php:

- Die zu `'neues_entry_publish_error'` und `'neues_entry_publish_success'` gehörenden .lang-Einträge werden als Template in sprintf genutzt. Der vorkommende Platzhalter `%s` ist für Strings, abr tatsächlich wird eine Zahl eingefügt; Alle .lang-Dateien geändert auf `%d`.

Restful.php:

- Die Elemente `...[get][fields] haben ja den jeweiligen Klassennamen inkl. Namespace in ausgeschriebener Form. Daher habe ich die Texte in die ::class-Schreibweise geändert (`Entry::class` usw.)

Rss.php:

- RexStan tut sich mit sowas wie `$category_id && $category = Category::get($category_id)`schwer. Das hab ich aufgelöst.
- Es gibt zwei `TODO:`-Vermerke, weil es einen Parameter `domain` gibt, der aber tatsächlich nicht benutzt wird. Ich kann nicht entscheiden, ob der weg kann. Wenn er bleibt muss der Typ anggeben werden.

