### PR TITLE
Status-Abfrage "online":  >= in = geändert

### DIFF
--- a/lib/Api/Restful.php
+++ b/lib/Api/Restful.php
@@ -17,7 +17,7 @@ class Restful
                 'path' => '/neues/entry/5.0.0/',
                 'auth' => '\rex_yform_rest_auth_token::checkToken',
                 'type' => Entry::class,
-                'query' => Entry::query()->where('status', 1, '>='),
+                'query' => Entry::query()->where('status', 1, '='),
                 'get' => [
                     'fields' => [
                         Entry::class => [
@@ -105,7 +105,7 @@ class Restful
                 'path' => '/neues/category/5.0.0/',
                 'auth' => '\rex_yform_rest_auth_token::checkToken',
                 'type' => Category::class,
-                'query' => Category::query()->where('status', 1, '>='),
+                'query' => Category::query()->where('status', 1, '='),
                 'get' => [
                     'fields' => [
                         Category::class => [

--- a/lib/Api/Restful.php
+++ b/lib/Api/Restful.php
@@ -17,7 +17,7 @@ class Restful
                 'path' => '/neues/entry/5.0.0/',
                 'auth' => '\rex_yform_rest_auth_token::checkToken',
                 'type' => Entry::class,
-                'query' => Entry::query()->where('status', 1, '='),
+                'query' => Entry::query()->where('status', 1),
                 'get' => [
                     'fields' => [
                         Entry::class => [
@@ -105,7 +105,7 @@ class Restful
                 'path' => '/neues/category/5.0.0/',
                 'auth' => '\rex_yform_rest_auth_token::checkToken',
                 'type' => Category::class,
-                'query' => Category::query()->where('status', 1, '='),
+                'query' => Category::query()->where('status', 1),
                 'get' => [
                     'fields' => [
                         Category::class => [

--- a/lib/Entry.php
+++ b/lib/Entry.php
@@ -501,7 +501,7 @@ class Entry extends rex_yform_manager_dataset
         if (null !== $category_id) {
             return self::findByCategory($category_id);
         }
-        return self::query()->where('status', 1, '=')->find();
+        return self::query()->where('status', 1)->find();
     }
 
     /**
@@ -521,7 +521,7 @@ class Entry extends rex_yform_manager_dataset
     {
         $query = self::query();
         $alias = $query->getTableAlias();
-        $query->joinRelation('category_ids', 'c')->where($alias . '.status', $status, '=')->where('c.id', $category_id);
+        $query->joinRelation('category_ids', 'c')->where($alias . '.status', $status)->where('c.id', $category_id);
         return $query->find();
     }
 
@@ -540,7 +540,7 @@ class Entry extends rex_yform_manager_dataset
      */
     public static function findByCategoryIds(string|array|null $category_ids = null, int $status = 1): rex_yform_manager_collection
     {
-        $query = self::query()->where('status', $status, '=');
+        $query = self::query()->where('status', $status);
 
         if ($category_ids) {
             // Wenn es ein String ist, in ein Array umwandeln

--- a/lib/Entry.php
+++ b/lib/Entry.php
@@ -501,7 +501,7 @@ class Entry extends rex_yform_manager_dataset
         if (null !== $category_id) {
             return self::findByCategory($category_id);
         }
-        return self::query()->where('status', 1, '>=')->find();
+        return self::query()->where('status', 1, '=')->find();
     }
 
     /**
@@ -521,7 +521,7 @@ class Entry extends rex_yform_manager_dataset
     {
         $query = self::query();
         $alias = $query->getTableAlias();
-        $query->joinRelation('category_ids', 'c')->where($alias . '.status', $status, '>=')->where('c.id', $category_id);
+        $query->joinRelation('category_ids', 'c')->where($alias . '.status', $status, '=')->where('c.id', $category_id);
         return $query->find();
     }
 
@@ -540,7 +540,7 @@ class Entry extends rex_yform_manager_dataset
      */
     public static function findByCategoryIds(string|array|null $category_ids = null, int $status = 1): rex_yform_manager_collection
     {
-        $query = self::query()->where('status', $status, '>=');
+        $query = self::query()->where('status', $status, '=');
 
         if ($category_ids) {
             // Wenn es ein String ist, in ein Array umwandeln

--- a/lib/neues.php
+++ b/lib/neues.php
@@ -27,7 +27,7 @@ class Neues
     public static function getList(int $rowsPerPage = 10, string $pageCursor = 'page'): string
     {
         $query = Entry::query()
-            ->where('status', 1, '>=')
+            ->where('status', 1, '=')
             ->where('publishdate', rex_sql::datetime(), '<=')
             ->orderBy('publishdate', 'desc');
         $pager = new rex_pager($rowsPerPage, $pageCursor);

--- a/lib/neues.php
+++ b/lib/neues.php
@@ -27,7 +27,7 @@ class Neues
     public static function getList(int $rowsPerPage = 10, string $pageCursor = 'page'): string
     {
         $query = Entry::query()
-            ->where('status', 1, '=')
+            ->where('status', 1)
             ->where('publishdate', rex_sql::datetime(), '<=')
             ->orderBy('publishdate', 'desc');
         $pager = new rex_pager($rowsPerPage, $pageCursor);


### PR DESCRIPTION
An mehreren Stellen wird wenn ich nicht gänzlich irre auf "status ist 'online'" überprüft. Allerdings nicht auf `status == 1`, sondern `status >= 1`. 

Das ist aktuell unschädlich bei Kategorien, denn dort gibt es nur `-1`(draft) und `1` (online). Bei den Entries ist es anders. Es gibt auch `2`(deleted). Eine Abfrage auf "online" würde also neben den Online-Artikeln auch die gelöschten liefern. Und Gelöschtes kann per defiition nicht online sein. 

https://github.com/FriendsOfREDAXO/neues/blob/c770420b81327111de74167b9a9d09ea16b74eff/lib/Entry.php#L499-L505

Der PR setzt den Vergleichsoperator auf  `=` statt `>=` bzwl öäscht ihn, da `=`der Default ist