### PR TITLE
RexStan-Überprüfung: pages/neues.docs.php

### DIFF
--- a/pages/neues.docs.php
+++ b/pages/neues.docs.php
@@ -6,7 +6,7 @@
  */
 
 $mdFiles = [];
-foreach (glob(rex_addon::get('neues')->getPath('docs') . '/*.md') ?: [] as $file) {
+foreach (glob(rex_path::addon('neues', 'docs/*.md')) as $file) {
     $mdFiles[mb_substr(basename($file), 0, -3)] = $file;
 }
 


### PR DESCRIPTION
RexStan beschwert sich über den ternären Operator (`glob(....) ?: []`): 
**'Short ternary operator is not allowed. Use null coalesce operator if applicable or consider using long ternary.'**

M.e. kann auf die Absicherung vezichtet werden, denn wenn es den Pfad nicht gibt oder für den Pfad keine Leseberechtigung vorliegt oder keine Datei dem Schema entspricht, bekommt man eh ein leeres Array. 

Um an den Pfad zu kommen, muss man sich kein Addon-Objekt holen (`rex_addon::get('neues')->getPath('docs') . '/*.md'`). Es reicht ein `rex_path::addon('neues', 'docs/*.md')`;
 