### PR TITLE
RexStan-Überprüfung: lib/Category.php

### DIFF
--- a/lib/Category.php
+++ b/lib/Category.php
@@ -91,7 +91,7 @@ class Category extends rex_yform_manager_dataset
      */
     public function getUrl(string $profile = 'neues-category-id'): string
     {
-       return rex_getUrl(null, null, [$profile => $this->getId()]);
+        return rex_getUrl(null, null, [$profile => $this->getId()]);
     }
 
     /**

--- a/lib/Category.php
+++ b/lib/Category.php
@@ -23,7 +23,9 @@ use rex_yform_manager_dataset;
  */
 class Category extends rex_yform_manager_dataset
 {
+    /** @api */
     public const DRAFT = -1;
+    /** @api */
     public const ONLINE = 1;
 
     /**
@@ -80,19 +82,16 @@ class Category extends rex_yform_manager_dataset
      * Returns the URL of the Category.
      *
      * @param string $profile Das Profil, das für die URL-Erstellung verwendet wird. Standardmäßig 'neues-category-id'. / The profile used for URL creation. Defaults to 'neues-category-id'.
-     * @return string Die URL der Kategorie oder ein leerer String, wenn keine URL gefunden wurde. / The URL of the Category or an empty string if no URL was found.
+     * @return string Die URL der Kategorie. / The URL of the Category.
      *
      * Beispiel / Example:
      * $url = $category->getUrl();
      *
      * @api
      */
-    public function getUrl(string $profile = 'neues-category-id'): ?string
+    public function getUrl(string $profile = 'neues-category-id'): string
     {
-        if ($url = rex_getUrl(null, null, [$profile => $this->getId()])) {
-            return $url;
-        }
-        return null;
+       return rex_getUrl(null, null, [$profile => $this->getId()]);
     }
 
     /**


### PR DESCRIPTION
**'Public constant "FriendsOfRedaxo\Neues\Category::DRAFT" is never used'**

Na gut, `/** @pi*/`ergänzt.


**'Only booleans are allowed in an if condition, string given.'**

Da `rex_getUrl` immer eine Url erzeugt, ist die Abfrage an sich obsolet. Es wird nie auf `null` oder `''` hinauslaufen.
Daher auch Kommentare und Return-Type angepasst.

