### PR TITLE
RexStan-Überprüfung: fragments/neues/entry.php

### DIFF
--- a/fragments/neues/entry.php
+++ b/fragments/neues/entry.php
@@ -19,7 +19,7 @@ $post = $this->getVar('post');
                 <?php endif ?>
 
                 <!-- Date -->
-                <?php if ($post->getPublishDate()) : ?>
+                <?php if ('' < $post->getPublishDate()) : ?>
                     <p class="blog-post-meta">
                         <?= $post->getFormattedPublishDate() ?>
 
@@ -56,9 +56,10 @@ $post = $this->getVar('post');
                 <?php endif ?>
 
                 <!-- Post Images/Gallery -->
-                <?php if ($post->getImages()) : ?>
+                <?php $images = $post->getImages(); 
+                      if (0 < count($images)) : ?>
                     <div class="mt-5 row g-3">
-                        <?php foreach ($post->getImages() as $image) : ?>
+                        <?php foreach ($images as $image) : ?>
                             <?php
                             $media = rex_media::get($image);
                             $mediaUrl = rex_media_manager::getUrl('rex_media_medium', $image);

--- a/fragments/neues/entry.php
+++ b/fragments/neues/entry.php
@@ -56,7 +56,7 @@ $post = $this->getVar('post');
                 <?php endif ?>
 
                 <!-- Post Images/Gallery -->
-                <?php $images = $post->getImages(); 
+                <?php $images = $post->getImages();
                       if (0 < count($images)) : ?>
                     <div class="mt-5 row g-3">
                         <?php foreach ($images as $image) : ?>


### PR DESCRIPTION
**'Only booleans are allowed in an if condition, string given.'**

Da `$post->getPublishDate()` immer einen String liefert, besser auf "nicht `''`" abfragen.

**'Only booleans are allowed in an if condition, array|null given.'**

`$post->getImages()` liefert real immer ein Array. Somit reicht es aus, hier auf 
ein leeres Array zu prüfen. Damit das Array nicht zweimal erzeugt und abgerufen wird, dient `$images` als Zwischenspeicher.
