### PR TITLE
RexStan-Überprüfung: fragments/neues/list.php

### DIFF
--- a/fragments/neues/list.php
+++ b/fragments/neues/list.php
@@ -2,33 +2,35 @@
 
 /** @var rex_fragment $this */
 
+use FriendsOfRedaxo\Neues\Entry;
+
 /** @var rex_pager $pager */
 $pager = $this->getVar('pager');
 
-/** @var rex_yform_manager_collection $posts */
+/** @var rex_yform_manager_collection<Entry> $posts */
 $posts = $this->getVar('posts');
 ?>
 
 <!-- Entry list -->
 <div class="container">
     <div class="row row-cols-1 row-cols-md-2 g-3">
-        <?php foreach ($posts as $post) : ?>
-            <?php if($post) { ?>
-            <div class="col">
-                <?php
-                $fragment = new rex_fragment();
-                $fragment->setVar('post', $post);
-                echo $fragment->parse('neues/list-entry.php');
-                ?>
-            </div>
-            <?php } else { ?>
-                <div class="placeholder">
-                    <?php if(rex_config::get('neues', 'no_entries_placeholder')) { ?>
+        <?php if(0 < count($posts)) { ?>
+            <?php foreach ($posts as $post) : ?>
+                <div class="col">
+                    <?php
+                    $fragment = new rex_fragment();
+                    $fragment->setVar('post', $post);
+                    echo $fragment->parse('neues/list-entry.php');
+                    ?>
+                </div>
+            <?php endforeach ?>
+        <?php } else { ?>
+            <div class="placeholder">
+                <?php if(null !== rex_config::get('neues', 'no_entries_placeholder')) { ?>
                     <p><?= rex_i18n::msg('no_entries_placeholder') ?></p>
                     <?php } ?>
                 </div>
             <?php } ?>
-        <?php endforeach ?>
     </div>
 </div>
 


### PR DESCRIPTION
**'PHPDoc tag @var for variable $posts contains generic class rex_yform_manager_collection but does not specify its types: T'**

Da fehlt die Angabe der Collection-Inhalte, also der ModelClass `Entry`: 
`/** @var rex_yform_manager_collection<Entry> $posts */`

**''Only booleans are allowed in an if condition, FriendsOfRedaxo\Neues\Entry|null given.''**

Die Fehlermeldung führt etwas in die falsche Richtung; das eigentliche Problem ist ein anderes. Hier stimmt nämlich die
Struktur nicht so ganz. 
```php
        <?php foreach ($posts as $post) : ?>
            <?php if($post) { ?>
            <div class="col">
                <?php
                $fragment = new rex_fragment();
                $fragment->setVar('post', $post);
                echo $fragment->parse('neues/list-entry.php');
                ?>
            </div>
            <?php } else { ?>
                <div class="placeholder">
                    <?php if(rex_config::get('neues', 'no_entries_placeholder')) { ?>
                    <p><?= rex_i18n::msg('no_entries_placeholder') ?></p>
                    <?php } ?>
                </div>
            <?php } ?>
        <?php endforeach ?>
```
Da die Schleife nur durchlaufen wird, wenn es auch $posts gibt, ist die Abfrage auf `if($post) ...`
nicht erforderlich. Es gibt den Post, sonst wäre er nicht in der Collection. Somit wird der else-Zweig (`no entries`)
nie erreicht, auch nicht bei einer leeren Liste. Daher den Code etwas umgebaut.

**'Only booleans are allowed in an if condition, mixed given.'**

Da `rex_config::get(...)` als Default `null` liefert, möchte RexStan dass expliziet darauf abgefragt wird.