### PR TITLE
RexStan-Überprüfung: uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -76,6 +76,12 @@ try {
      */
     $urlProfileTable = rex::getTable(Profile::TABLE_NAME);
 
+    /**
+     * RexStan: Unable to resolve the template type TFetchType in call to method rex_sql::getArray()
+     * RexStan: Parameter $fetchType of method rex_sql::getArray() expects 2|3|12, 7 given.
+     * Das liegt an rex_sql; dort sind nicht alle möglichen PDO::FETCH_... hinterlegt.
+     * kann man ignorieren
+     */
     $profiles = $sql->setTable($urlProfileTable)
         ->setWhere('table_name LIKE :tn', [':tn' => '1_xxx_rex_neues_%'])
         ->select('id')
@@ -83,6 +89,11 @@ try {
 
     foreach ($profiles as $profileId) {
         $profile = Profile::get($profileId);
+        /**
+         * RexStan: Strict comparison using !== between null and Url\Profile will always evaluate to true.
+         * Der Fehler ist im URL-Addon (https://github.com/tbaddade/redaxo_url/pull/301)
+         * TODO: wenn im URL-Addon behoben kann dieser Kommentar gelöscht werden.
+         */
         if (null !== $profile) {
             $profile->deleteUrls();
         }

--- a/uninstall.php
+++ b/uninstall.php
@@ -80,7 +80,7 @@ try {
      * RexStan: Unable to resolve the template type TFetchType in call to method rex_sql::getArray()
      * RexStan: Parameter $fetchType of method rex_sql::getArray() expects 2|3|12, 7 given.
      * Das liegt an rex_sql; dort sind nicht alle möglichen PDO::FETCH_... hinterlegt.
-     * kann man ignorieren
+     * kann man ignorieren.
      */
     $profiles = $sql->setTable($urlProfileTable)
         ->setWhere('table_name LIKE :tn', [':tn' => '1_xxx_rex_neues_%'])


### PR DESCRIPTION
Für beide "Fehler" findet hier keine Korrektur statt, auch kein `ignore-next-line`; Ich habe nur Kommentare eingefügt, damit man darum weiß, da sie nicht stören und vom Code her korrekt sind. Die Fehlerkorrektur muss woanders stattfinden.

**'Unable to resolve the template type TFetchType in call to method rex_sql::getArray()'** 
**'Parameter $fetchType of method rex_sql::getArray() expects 2|3|12, 7 given.'**

Beide Meldungen kann man hier ignorieren. Das liegt an rex_sql; dort sind einige häufige PDO::FETCH_... hinterlegt,
aber eben nicht alle. In diesem Fall ist `PDO::FETCH_COLUMN` eben unbekannt. Es hat aber keinerlei funktionale
Auswirkungen.

**'Strict comparison using !== between null and Url\Profile will always evaluate to true.'**

Der Fehler hier ist ignorierbar, denn der Problembär sitzt eine Zeile darüber mit der Referenz auf das Url-Addon.
Die Methode `$profile = Profile::get($profileId);` liefert angeblich immer eine Profil-Instanz (`@return self`), aber niemals null.
So gesehen ist die Abfrage `if (null !== $profile)` tatsächlich überflüssig. In der Realität liefert `Profile::get`
aber doch u.U. `null`. Der Fehler liegt also dort im unvollständigen Return-Type.

Siehe [PR beim URL-Addon](https://github.com/tbaddade/redaxo_url/pull/301)
