### PR TITLE
RexStan-Überprüfung: lib/Cronjob/Sync.php

### DIFF
--- a/lib/Cronjob/Sync.php
+++ b/lib/Cronjob/Sync.php
@@ -65,6 +65,8 @@ class Sync extends rex_cronjob
 
     /**
      * @param array<string,mixed> $current
+     * 
+     * TODO: klären, warum createAuthor bzw. createCategory ein entsprechendes Objekt zurückliefern, createEntry aber nicht. 
      */
     public function createEntry(array $current): void
     {
@@ -100,6 +102,7 @@ class Sync extends rex_cronjob
             $target_author = $this->createAuthor($author['attributes']);
             $entry->setValue('author_id', $target_author->getId());
         }
+        /* / Autor abrufen und speichern */
 
         /* Titelbild abrufen und speichern */
         $updated_image = '';

--- a/lib/Cronjob/Sync.php
+++ b/lib/Cronjob/Sync.php
@@ -65,8 +65,8 @@ class Sync extends rex_cronjob
 
     /**
      * @param array<string,mixed> $current
-     * 
-     * TODO: klären, warum createAuthor bzw. createCategory ein entsprechendes Objekt zurückliefern, createEntry aber nicht. 
+     *
+     * TODO: klären, warum createAuthor bzw. createCategory ein entsprechendes Objekt zurückliefern, createEntry aber nicht.
      */
     public function createEntry(array $current): void
     {


### PR DESCRIPTION
RexStan-Überprüfung (Level 6, REDAXO SuperGlobals|Strict-Mode|Deprecation Warnings|phpstan-dba|report mixed|dead code)

**'Property FriendsOfRedaxo\Neues\Cronjob\Sync::$counter has no type specified.'**

`/** @var ... */` hinzugefügt

**'PHPDoc tag @var for variable $response contains unknown class .....\Cronjob\rex_socket_response.'**
**'Call to method xyz() on an unknown class .....\Cronjob\rex_socket_response.'**

An zwei Stellen steht

```php
$socket = rex_socket::factoryUrl($socket_url);
/** @var rex_socket_response $response */
$response = $socket->doGet();
```

Faktisch funtioniert der Code, denn `rex_socket` ist per Use korrekt eingeordnet und `$socket->doGet()`liefert ein `\rex_socket_response`-Objekt. Somit ist der PHPDoc-Tag überflüssig. Rexstan und die IDE werten die Rückgabe auch so korrekt aus.

Damit erledigen sich zugleich die Fehlermeldungen zu 'Call to method xyz() on an unknown class ...\rex_socket_response'.

**'Method FriendsOfRedaxo\Neues\Cronjob\Sync::createEntry() has no return type specified.'**
**'Method FriendsOfRedaxo\Neues\Cronjob\Sync::createEntry() has parameter $current with no value type specified in iterable type array.'**

**'Method FriendsOfRedaxo\Neues\Cronjob\Sync::createEntry() has parameter $current with no value type specified in iterable type array.'**
**'Method FriendsOfRedaxo\Neues\Cronjob\Sync::createCategory() has parameter $current with no type specified.'**

**'Method FriendsOfRedaxo\Neues\Cronjob\Sync::createAuthor() has no return type specified.'**
**'Method FriendsOfRedaxo\Neues\Cronjob\Sync::createAuthor() has parameter $current with no value type specified in iterable type array.'**

Der Paramter ist ersteinmal mangels besserer Erkenntnis auf `@param array<string,mixed> $current` gesetzt. Der Return-Typ ist passend gesetzt zu dem, was die jeweilige Methode macht (`void`, `Category`, `Author`).

Zu klären wäre, warum `createAuthor` bzw. `createCategory` ein entsprechendes Objekt zurückliefern, `createEntry` aber nicht. 

**'If condition is always true.'**

Kommt an zwei Stellen vor. Hier nur einmal beschrieben:

Da `createCategory` stets ein Category-Objekt liefert (s.o.), kann die Abfrage entfallen.

```php
$target_category = $this->createCategory($category['attributes']);
if ($target_category) {
    $target_category_ids[] = $target_category->getId();
}
```

**'Only booleans are allowed in &&, FriendsOfRedaxo\Neues\Category|null given on the right side.'**

Die Abfrage konkret gestaltet; auf `not null` abfragen:
```php
if ($this->getParam('neues_category_id') > 0 && null !== Category::get($this->getParam('neues_category_id'))) {
```

**'Only booleans are allowed in an if condition, mixed given.'**

Hier sollte wohl eher abgefragt werden, ob das Array-Element existiert.

```php
$author = $current['relationships']['author']['data'];
if ($author) {
    $target_author = $this->createAuthor($author['attributes']);
    $entry->setValue('author_id', $target_author->getId());
}
```

wird zu 
```php
if (isset($current['relationships']['author']['data'])) {
    $author = $current['relationships']['author']['data'];
    $target_author = $this->createAuthor($author['attributes']);
    $entry->setValue('author_id', $target_author->getId());
}
```

**'Only booleans are allowed in an if condition, rex_media|null given.'**

Auch hier konkret prüfen (`null !== ...`).

**'Only booleans are allowed in a ternary operator condition, array given.'**

```php
return rex_media_service::addMedia(...) ? true : false;
```

RexStan moniert, dass es kein konkreter Vergleich ist. Erschwerend kommt hinzu, dass immer
ein gefülltes Array geliefert wird; die Abfrage ergibt also immrer True. Im Fehlerfall kommt eine Exception.

Also muss man die Exception abfangen und dann false melden