### PR TITLE
Umstellung Status "DELETED" von 2 auf -2

### DIFF
--- a/install.php
+++ b/install.php
@@ -11,6 +11,7 @@ use rex_media;
 use rex_media_service;
 use rex_path;
 use rex_sql;
+use rex_version;
 use rex_yform_manager_table_api;
 use Url\Cache;
 use Url\Profile;
@@ -111,4 +112,17 @@ if (rex_addon::get('url')->isAvailable()) {
         // URL-Profile als installiert markieren
         rex_config::set('neues', 'url_profile', true);
     }
+}
+
+
+/**
+ * Beim Update einer Version vor 5.1.0 wird ein Fehler bei den Status-Werten
+ * korrigiert. Deleted wird von 2 auf -2 geändert.
+ */
+if (rex_version::compare('5.1.0', $$this->getVersion(), '>')) {
+    $sql = rex_sql::factory();
+    $sql->setTable('neues_entry');
+    $sql->setWhere('status',2);
+    $sql->setValue('status',-2);
+    $sql->update();
 }

--- a/install.php
+++ b/install.php
@@ -114,7 +114,6 @@ if (rex_addon::get('url')->isAvailable()) {
     }
 }
 
-
 /**
  * Beim Update einer Version vor 5.1.0 wird ein Fehler bei den Status-Werten
  * korrigiert. Deleted wird von 2 auf -2 geändert.
@@ -122,7 +121,7 @@ if (rex_addon::get('url')->isAvailable()) {
 if (rex_version::compare('5.1.0', $$this->getVersion(), '>')) {
     $sql = rex_sql::factory();
     $sql->setTable('neues_entry');
-    $sql->setWhere('status',2);
-    $sql->setValue('status',-2);
+    $sql->setWhere('status', 2);
+    $sql->setValue('status', -2);
     $sql->update();
 }

--- a/lib/Entry.php
+++ b/lib/Entry.php
@@ -33,9 +33,13 @@ use function is_string;
  */
 class Entry extends rex_yform_manager_dataset
 {
-    public const DELETED = 2; // FIXME: muss auf -2 geändert werden.
+    /** @api */
+    public const DELETED = -2;
+    /** @api */
     public const DRAFT = -1;
+    /** @api */
     public const PLANNED = 0;
+    /** @api */
     public const ONLINE = 1;
 
     /**


### PR DESCRIPTION
Der Status-Code für DELETED steht z.Zt. irrtümlich auf 2 statt -2 (https://github.com/FriendsOfREDAXO/neues/pull/101#issuecomment-2334733984).

der PR fügt in die _install.php_ Code ein, der beim erstmaligen Update auf eine Version 5.1 oder größer den Wert in der Datenbank auf -2 korrigiert. Analog dazu ist Entry angepasst. 