### PR TITLE
API getuned, neue Methoden findBy/queryBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## xx-xx-2024 x.x.x (**Breacking Changes ⚠**)
+
+> Work in Progress !!!
+
+Version x.x.x ist an vielen Ständen überarbeitet, was auch die Schnittstellen der
+Klassen/Methoden betrifft. Beim Update von Versionen vor x.x.x müssen ggf. Anpassungen
+im eigenen Code vorgenommen werden:
+
+- Klasse `Author`:
+  - alter Klassenname: `neues_author` => neu: `FriendsOfRedaxo\Neues\Author`
+  - `$author->getName`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt
+  - `$author->getNickName`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt
+  - `$author->geText`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt
+  - `$author->getBeUserId`: liefert immer eine Id vom Typ`int` (0=unbekannt); `null` als Rückgabe ist entfernt
+- Klasse `Category`:
+  - alter Klassenname: `neues_category` => neu: `FriendsOfRedaxo\Neues\Category`
+  - `$cat->getName`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt
+- Klasse `Entry`:
+  - alter Klassenname: `neues_entry` => neu: `FriendsOfRedaxo\Neues\Entry`
+  - `$post->getImages`: API angepasst auf `array`, da ohnehin stets ein ggf. leeres Array geliefert wurde, aber nie `null`
+  - `$post->setImages`: `null` für "leer also löschen" wird nicht mehr akzeptiert; statt dessen `[]`benutzen oder den Parameter weglassen.
+  - `$post->getExternalUrl`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt.
+  - `$post->getStatus`: liefert nun richtigerweise `int` statt `string`
+  - `Entry::findOnline`: `null` als "suche alle"-Kennung durch `0`ersetzt.
+  - `Entry::findByCategory`: `null` als "suche alle"-Kennung durch `0`ersetzt.
+  - `Entry::findByCategoryIds`: `null` als "suche alle"-Kennung durch `0`ersetzt.
+  - neu: `$post->getCanonicalUrl`
+  - neu: `$post->setCanonicalUrl`
+  - neu: `Entry::queryBy`
+  - neu: `Entry::findBy`
+- Klasse `EntryLang`
+  - alter Klassenname: `neues_entry_lang` => neu: `FriendsOfRedaxo\Neues\EntryLang`
+  - `$cat->getCode`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt
+  - `$cat->geName`: liefert immer einen ggf. leeren `string`; `null` als Rückgabe ist entfernt
+- Klasse `Entry`:
+  - alter Klassenname: `neues` => neu: `FriendsOfRedaxo\Neues\Neues`

--- a/docs/03_neues_entry.md
+++ b/docs/03_neues_entry.md
@@ -236,7 +236,7 @@ Setzt den Status des Eintrags.
 $entry = $entry->setStatus(1);
 ```
 
-### findOnline(?int $category_id = null)
+### findOnline(int $category_id = 0)
 
 Findet Online-Eintr채ge. Wenn eine Kategorie-ID angegeben ist, werden nur Eintr채ge aus dieser Kategorie zur체ckgegeben.
 
@@ -244,7 +244,7 @@ Findet Online-Eintr채ge. Wenn eine Kategorie-ID angegeben ist, werden nur Eintr�
 $entries = FriendsOfRedaxo\Neues\Entry::findOnline(1);
 ```
 
-### findByCategory(?int $category_id = null, int $status = Entry::ONLINE)
+### findByCategory(int $category_id = 0, int $status = Entry::ONLINE)
 
 Findet Eintr채ge nach Kategorie.
 

--- a/fragments/neues/entry.php
+++ b/fragments/neues/entry.php
@@ -25,7 +25,7 @@ $post = $this->getVar('post');
 
                         <!-- Author -->
                         <?php if (null !== $post->getAuthor()) : ?>
-                            <?php if (null !== $post->getAuthor()->getName()) : ?>
+                            <?php if ('' !== $post->getAuthor()->getName()) : ?>
                                 von <span><?= htmlspecialchars($post->getAuthor()->getName()) ?></span>
                             <?php elseif(null !== $post->getAuthor()->getNickname()): ?>
                                 von <span><?= htmlspecialchars($post->getAuthor()->getNickname()) ?></span>

--- a/lib/Author.php
+++ b/lib/Author.php
@@ -29,16 +29,19 @@ class Author extends rex_yform_manager_dataset
      * Gibt den Namen des Autors zurück.
      * Returns the name of the author.
      *
-     * @return string|null Der Name des Autors oder null, wenn kein Name gesetzt ist. / The name of the author or null if no name is set.
+     * @return string Der Name des Autors oder '', wenn kein Name gesetzt ist. / The name of the author or '' if no name is set.
      *
      * Beispiel / Example:
      * $name = $author->getName();
      *
      * @api
      */
-    public function getName(): ?string
+    public function getName(): string
     {
-        return $this->getValue('name');
+        if ($this->hasValue('name')) {
+            return $this->getValue('name');
+        }
+        return '';
     }
 
     /**
@@ -60,16 +63,19 @@ class Author extends rex_yform_manager_dataset
      * Gibt den Spitznamen des Autors zurück.
      * Returns the nickname of the author.
      *
-     * @return string|null Der Spitzname des Autors oder null, wenn kein Spitzname gesetzt ist. / The nickname of the author or null if no nickname is set.
+     * @return string Der Spitzname des Autors oder '', wenn kein Spitzname gesetzt ist. / The nickname of the author or '' if no nickname is set.
      *
      * Beispiel / Example:
      * $nickname = $author->getNickname();
      *
      * @api
      */
-    public function getNickname(): ?string
+    public function getNickname(): string
     {
-        return $this->getValue('nickname');
+        if ($this->hasValue('nickname')) {
+            return $this->getValue('nickname');
+        }
+        return '';
     }
 
     /**
@@ -92,19 +98,19 @@ class Author extends rex_yform_manager_dataset
      * Returns the text of the author.
      *
      * @param bool $asPlaintext Wenn true, wird der Text ohne HTML-Tags zurückgegeben. / If true, the text is returned without HTML tags.
-     * @return string|null Der Text des Autors oder null, wenn kein Text gesetzt ist. / The text of the author or null if no text is set.
+     * @return string Der Text des Autors oder '', wenn kein Text gesetzt ist. / The text of the author or '' if no text is set.
      *
      * Beispiel / Example:
      * $text = $author->getText(true);
      *
      * @api
      */
-    public function getText(bool $asPlaintext = false): ?string
+    public function getText(bool $asPlaintext = false): string
     {
-        if ($asPlaintext) {
-            return strip_tags($this->getValue('text'));
+        if ($this->hasValue('text')) {
+            return $asPlaintext ? strip_tags($this->getValue('text')) : $this->getValue('text');
         }
-        return $this->getValue('text');
+        return '';
     }
 
     /**
@@ -126,16 +132,19 @@ class Author extends rex_yform_manager_dataset
      * Gibt die Benutzer-ID des Autors zurück.
      * Returns the user ID of the author.
      *
-     * @return int|null Die Benutzer-ID des Autors oder null, wenn keine Benutzer-ID gesetzt ist. / The user ID of the author or null if no user ID is set.
+     * @return int Die Benutzer-ID des Autors oder 0, wenn keine Benutzer-ID gesetzt ist. / The user ID of the author or 0 if no user ID is set.
      *
      * Beispiel / Example:
      * $beUserId = $author->getBeUserId();
      *
      * @api
      */
-    public function getBeUserId(): ?int
+    public function getBeUserId(): int
     {
-        return (int) $this->getValue('be_user_id');
+        if ($this->hasValue('be_user_id')) {
+            return (int) $this->getValue('be_user_id');
+        }
+        return 0;
     }
 
     /**
@@ -165,6 +174,10 @@ class Author extends rex_yform_manager_dataset
      */
     public function getBeUser(): ?rex_user
     {
-        return rex_user::get($this->getBeUserId());
+        $userId = $this->getBeUserId();
+        if (0 !== $userId) {
+            return rex_user::get($userId);
+        }
+        return null;
     }
 }

--- a/lib/Category.php
+++ b/lib/Category.php
@@ -41,7 +41,10 @@ class Category extends rex_yform_manager_dataset
      */
     public function getName(): string
     {
-        return $this->getValue('name');
+        if ($this->hasValue('name')) {
+            return $this->getValue('name');
+        }
+        return '';
     }
 
     /**
@@ -65,7 +68,7 @@ class Category extends rex_yform_manager_dataset
      * Gibt die Einträge der Kategorie zurück.
      * Returns the entries of the Category.
      *
-     * @return rex_yform_manager_collection<Entry> Die Einträge der Kategorie oder null, wenn keine Einträge vorhanden sind. / The entries of the Category or null if no entries are present.
+     * @return rex_yform_manager_collection<Entry> Die Einträge der Kategorie oder leere Liste, wenn keine Einträge vorhanden sind. / The entries of the Category or empty list if no entries are present.
      *
      * Beispiel / Example:
      * $entries = $category->getEntries();

--- a/lib/EntryLang.php
+++ b/lib/EntryLang.php
@@ -38,16 +38,19 @@ class EntryLang extends rex_yform_manager_dataset
      * Gibt den Code der Sprache zurück.
      * Returns the code of the language.
      *
-     * @return string|null Der Code der Sprache oder null, wenn kein Code gesetzt ist. / The code of the language or null if no code is set.
+     * @return string Der Code der Sprache oder '', wenn kein Code gesetzt ist. / The code of the language or '' if no code is set.
      *
      * Beispiel / Example:
      * $code = $language->getCode();
      *
      * @api
      */
-    public function getCode(): ?string
+    public function getCode(): string
     {
-        return $this->getValue('code');
+        if ($this->hasValue('code')) {
+            return $this->getValue('code');
+        }
+        return '';
     }
 
     /**
@@ -77,7 +80,10 @@ class EntryLang extends rex_yform_manager_dataset
      */
     public function getName(): string
     {
-        return $this->getValue('name');
+        if ($this->hasValue('name')) {
+            return $this->getValue('name');
+        }
+        return '';
     }
 
     /**


### PR DESCRIPTION
Im API der diversen Abfragemethoden bzw. Getter habe ich bei den Typen konsequent die "null" Option entfernt, der typ st m.E. nicht erforderlich, da anderweitig und damit durch einfachere Datentyp-Kombinationen ersetztbar. Beispiel: 0 als Indikator für "keine Einschränkung, suche alle", denn 0 ist ja eh keine vorkommende Datensatz-ID.

Getter liefern jetzt immer einen typadäquaten Wert. Auch als Beispiel: `getName(): ?string` ist ersetzt durch `getName(): string`. Null ist keine wirkliche Hilfe wenn man zusätzlich trotzdem auf `` abfragen müsste. Wer wissen will, ob das Feld belegt ist, kann ja immer noch 'hasValue' bemühen. Die Getter fragen nun erst hasValue ab und liefern erst dann den Wert und ansonsten `''` bzw. `0`.

Zwei zusätzliche Methoden bei Entry: 

`queryBy` ist eine Methode zum Bau einer Query mit den diversen Filtern, `findBy` dasselbe aber mit ausgeführtem find(). Die Parameter sind identisch.

```php
public static function findBy(
    int|array|string $category = [], 
    int|array|bool $status = [], 
    string|int $lang = -1, 
    int|array|string $author = []
): rex_yform_manager_collection
```

- Kategorie (string `'1,2,3'`, int `1`, array [1,2,3])
- Status (int `Entry::ONLINE`, array `[Entry::DRAFT,Entry::PLANNED`, bool `Entry::IS_ONLINE`)
- Sprache (string `'de'`, int `1`)
- Autor (int `1`, array `[1,2]`, string `'1,2'`)

Leere Werte (`[]` bzw. -1) bedeuten: kein Filter. Bei der Sprche ist das -1, weil 0 die Bedeutung "für alle Sprachen" hat und eine Suche nach Sprache `n` immer eine Suche nach `[0,n]` ist. 

Man könnte im nächsten Schritt die vorhandenen find-Methoden überprüfen und in Aufrufe von findBy ändern oder evtl auch ganz rauswerfen. 

  