### PR TITLE
$_REQUEST-Nutzung aufgelöst

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -6,13 +6,9 @@ use rex;
 use rex_addon;
 use rex_api_function;
 use rex_cronjob_manager;
-use rex_csrf_token;
 use rex_extension;
 use rex_plugin;
-use rex_url;
 use rex_yform_manager_dataset;
-
-use function count;
 
 /**
  * Tabellen in YForm mit eigener Model-Class.
@@ -53,9 +49,6 @@ if (rex_plugin::get('yform', 'rest')->isAvailable()) {
 }
 
 if (rex::isBackend()) {
-    $addon = rex_addon::get('neues');
-    $pages = $addon->getProperty('pages');
-
     /**
      * Individualiserte Liste für Enries.
      */
@@ -63,23 +56,6 @@ if (rex::isBackend()) {
 
     /**
      * Plus(Add)-Button im Hauptmenü-Punkt des Addon bereitstellen.
-     *
-     * RexStan: Using $_REQUEST is forbidden, use rex_request::request() or rex_request() instead.
-     * Kommentar: Für diese Nutzung ist keine rex-Alternative verfügbar
-     * @phpstan-ignore-next-line
      */
-    if (0 < count($_REQUEST)) {
-        $_csrf_key = Entry::table()->getCSRFKey();
-
-        $params = rex_csrf_token::factory($_csrf_key)->getUrlParams();
-
-        $params['table_name'] = Entry::table()->getTableName(); // Tabellenname anpassen
-        $params['rex_yform_manager_popup'] = '0';
-        $params['func'] = 'add';
-
-        $href = rex_url::backendPage('neues/entry', $params);
-
-        $pages['neues']['title'] .= ' <a class="label label-primary tex-primary" style="position: absolute; right: 18px; top: 10px; padding: 0.2em 0.6em 0.3em; border-radius: 3px; color: white; display: inline; width: auto;" href="' . $href . '">+</a>';
-        $addon->setProperty('pages', $pages);
-    }
+    rex_extension::register('PAGES_PREPARED', Neues::epPagesPrepared(...));
 }

--- a/lib/neues.php
+++ b/lib/neues.php
@@ -69,11 +69,9 @@ class Neues
     }
 
     /**
-     * Hilfsklasse für JSON-LD Fragmente
-     * 
+     * Hilfsklasse für JSON-LD Fragmente.
+     *
      * @api
-     * @param string $value 
-     * @return string 
      */
     public static function htmlEncode(string $value): string
     {
@@ -81,7 +79,7 @@ class Neues
     }
 
     /**
-     * EP-Callback für PAGES_PREPARED
+     * EP-Callback für PAGES_PREPARED.
      *
      * Ergänzt den Backend-Menüpunkt um einen Plus-Button. Dies aber nur dann,
      * wenn die Instanz nicht via Redaxo-Konsole aufgerufen wurde.


### PR DESCRIPTION
Die von RexStan monierte Nutzung von $_REQUEST (`if(0 < count($_REQUEST))...`) ist durch die Abfrage des Console-Objektes abgelöst. Abhängig von der Frage wurde dem Addon-Titel in der Navigation ein Plus-Button angehängt.

Zu weiteren Einzelheiten des Wie und Warum siehe [hier](https://github.com/redaxo/redaxo/issues/6127#issuecomment-2354920027).

Der Code dazu wurde nach `Neues::epPagesPrepared` verlagert. Die _boot.php_ wird dadurch schlanker und übersichtlcher. Nebeneffekt: per Saldo wird weniger Code via _boot.php_ compiliert und abgearbeitet, da die meisten Seitenaufrufe i.d.R. via FE und nicht BE erfolgen.

RexStan ist einverstanden