### PR TITLE
Cronjob darf nicht andere Cronjobs blockieren

### DIFF
--- a/lib/Cronjob/Sync.php
+++ b/lib/Cronjob/Sync.php
@@ -247,7 +247,7 @@ class Sync extends rex_cronjob
                 'name' => 'url',
                 'label' => rex_i18n::msg('neues_entry_sync_cronjob_url'),
                 'type' => 'text',
-                'attributes' => ['required' => 'required', 'type' => 'url'],
+                'attributes' => ['type' => 'url'],
             ],
             [
                 'name' => 'token',


### PR DESCRIPTION
required-Attribut entfernen, da dies das Speichern aller Cronjobs verhindert (alle Cronjob-Formulare werden immer ausgeblendet ausgegeben)