### PR TITLE
BUGFIX: Übersetzungskey von Notice der Titel Überschrift behoben

### DIFF
--- a/install/tableset.json
+++ b/install/tableset.json
@@ -386,7 +386,7 @@
                 "attributes": "{\"required\":\"required\"}",
                 "default": "",
                 "no_db": "0",
-                "notice": "transalte:neues_name_notice",
+                "notice": "translate:neues_name_notice",
                 "append": "",
                 "prepend": ""
             },


### PR DESCRIPTION
**Beschreibung / Description**

Die Übersetzung der Notice für die Überschrift des Titels wird nun wieder korrekt angezeigt.
![image](https://github.com/user-attachments/assets/b8b2d7dd-6bef-4771-8aad-5bc0c60fb69e)

Allerdings muss man `yform` und `neues` einmal re-installieren. Wobei vermutlich auch `yform` reichen würde.