### PR TITLE
Extension Point zur Manipulation beliebiger Backend-YForm-Formularelemente

### DIFF
--- a/lib/Entry.php
+++ b/lib/Entry.php
@@ -6,6 +6,7 @@ use IntlDateFormatter;
 use rex_addon;
 use rex_config;
 use rex_csrf_token;
+use rex_extension;
 use rex_extension_point;
 use rex_formatter;
 use rex_i18n;
@@ -18,11 +19,6 @@ use rex_yform_manager_collection;
 use rex_yform_manager_dataset;
 use rex_yform_manager_query;
 use rex_yform_manager_table;
-
-use function count;
-use function is_bool;
-use function is_int;
-use function is_string;
 
 /**
  * Class Entry (ex. neues_entry).
@@ -55,14 +51,24 @@ class Entry extends rex_yform_manager_dataset
     public function getForm(): rex_yform
     {
         $yform = parent::getForm();
+        $elements = $yform->objparams['form_elements'];
 
+        $elements = rex_extension::registerPoint(new rex_extension_point(
+            'NEUES_ENTRY_FORM',
+            $elements,
+            [
+                'form_elements' => $elements,
+                'yform' => $yform
+            ]
+        ));
+        
         $suchtext = '###neues-settings-editor###';
-        foreach ($yform->objparams['form_elements'] as $k => &$e) {
+        foreach ($elements as $k => &$e) {
             if ('textarea' === $e[0] && str_contains($e[5], $suchtext)) {
                 $e[5] = str_replace($suchtext, rex_config::get('neues', 'editor'), $e[5]);
             }
         }
-
+        
         return $yform;
     }
 
@@ -547,7 +553,7 @@ class Entry extends rex_yform_manager_dataset
         if ($this->hasValue('status')) {
             return $this->getValue('status');
         }
-        return self::VOID;
+        return self::DRAFT;
     }
 
     /**

--- a/lib/Entry.php
+++ b/lib/Entry.php
@@ -20,6 +20,11 @@ use rex_yform_manager_dataset;
 use rex_yform_manager_query;
 use rex_yform_manager_table;
 
+use function count;
+use function is_bool;
+use function is_int;
+use function is_string;
+
 /**
  * Class Entry (ex. neues_entry).
  *
@@ -58,17 +63,17 @@ class Entry extends rex_yform_manager_dataset
             $elements,
             [
                 'form_elements' => $elements,
-                'yform' => $yform
-            ]
+                'yform' => $yform,
+            ],
         ));
-        
+
         $suchtext = '###neues-settings-editor###';
         foreach ($elements as $k => &$e) {
             if ('textarea' === $e[0] && str_contains($e[5], $suchtext)) {
                 $e[5] = str_replace($suchtext, rex_config::get('neues', 'editor'), $e[5]);
             }
         }
-        
+
         return $yform;
     }
 


### PR DESCRIPTION
close #135 

Die maximal-flexible Lösung, um selbst als Entwickler eingreifen zu können und vorab die Attribute programmatisch anzupassen, um bspw. weitere Data-Attribute für den cke5 mitzugeben. Oder je nach Berechtigung unterschiedliche Editor-Profile zur Verfügung zu stellen.

Auf der anderen Seite eine einfache Möglichkeit, nur die Klasse anzupassen (für Redactor oder MarkitUp, was dann in den Einstellungen auch so kommuniziert werden müsste.

Wenn das so stimmig ist, würde ich das auch in QandA, Events, Staff, Blaupause, ... implementieren.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an extension point to allow customization of form elements in entry forms.

- **Bug Fixes**
  - Improved status handling to ensure a valid default status is always returned for entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->