### PR TITLE
YForm-REST-API unter YForm >=5.0.0 verfügbar machen

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -52,7 +52,7 @@ if (version_compare(rex_addon::get('yform')->getVersion(), '5.0.0', '<')) {
         Api\Restful::init();
     }
 } else {
-        Api\Restful::init();
+    Api\Restful::init();
 }
 
 if (rex::isBackend()) {


### PR DESCRIPTION
closes #165 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Wartung

* **REST-API-Kompatibilität**: Die Initialisierung der REST-API wurde an verschiedene YForm-Versionen angepasst, um optimale Funktionalität über verschiedene Versionsumgebungen hinweg sicherzustellen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->